### PR TITLE
Get arp table

### DIFF
--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -332,7 +332,7 @@ class VyOSDriver(NetworkDriver):
         else:
             return None
 
-    def get_arp_table(self):
+    def get_arp_table(self, ip=None, mac=None, interface=None):
         # 'age' is not implemented yet
 
         """
@@ -361,6 +361,18 @@ class VyOSDriver(NetworkDriver):
                 macaddr = py23_compat.text_type("00:00:00:00:00:00")
             else:
                 macaddr = py23_compat.text_type(line[2])
+
+            if ip is not None:
+                if ip != py23_compat.text_type(line[0]):
+                    continue
+
+            if mac is not None:
+                if mac != macaddr:
+                    continue
+
+            if interface is not None:
+                if interface != py23_compat.text_type(line[-1]):
+                    continue
 
             arp_table.append(
                 {


### PR DESCRIPTION
According to issue https://github.com/napalm-automation/napalm-vyos/issues/17

Code for get_arp_table with params

Example output:

print mydevice.get_arp_table()
print ("specific params")
print mydevice.get_arp_table(ip='7.7.7.7')
print mydevice.get_arp_table(ip='10.0.2.3')
print mydevice.get_arp_table(ip='10.0.1.100')
print mydevice.get_arp_table(mac='52:54:00:12:00:00')
print mydevice.get_arp_table(mac='52:54:00:12:35:03')
print mydevice.get_arp_table(mac='08:00:27:27:03:8e')
print mydevice.get_arp_table(interface='eth0')
print mydevice.get_arp_table(interface='eth1')
print mydevice.get_arp_table(ip='10.0.2.3', interface='eth0')
print mydevice.get_arp_table(ip='10.0.2.3', interface='eth1')


[{'interface': u'eth0', 'ip': u'10.0.2.3', 'mac': u'52:54:00:12:35:03', 'age': 0.0}, {'interface': u'eth1', 'ip': u'10.0.1.100', 'mac': u'08:00:27:27:03:8e', 'age': 0.0}]
specific params
[]
[{'interface': u'eth0', 'ip': u'10.0.2.3', 'mac': u'52:54:00:12:35:03', 'age': 0.0}]
[{'interface': u'eth1', 'ip': u'10.0.1.100', 'mac': u'08:00:27:27:03:8e', 'age': 0.0}]
[]
[{'interface': u'eth0', 'ip': u'10.0.2.3', 'mac': u'52:54:00:12:35:03', 'age': 0.0}]
[{'interface': u'eth1', 'ip': u'10.0.1.100', 'mac': u'08:00:27:27:03:8e', 'age': 0.0}]
[{'interface': u'eth0', 'ip': u'10.0.2.3', 'mac': u'52:54:00:12:35:03', 'age': 0.0}]
[{'interface': u'eth1', 'ip': u'10.0.1.100', 'mac': u'08:00:27:27:03:8e', 'age': 0.0}]
[{'interface': u'eth0', 'ip': u'10.0.2.3', 'mac': u'52:54:00:12:35:03', 'age': 0.0}]
[]
